### PR TITLE
changed way id was collected for each cell

### DIFF
--- a/grid.js
+++ b/grid.js
@@ -31,7 +31,7 @@ function renderGrid() {
         for (let i = 0; i < numColumns; i++) {
             let square = document.createElement("div");
             square.className = "cell";
-            square.id = counter + "" + i;
+            square.id = counter + " " + i;
             square.style.backgroundColor = row[i].color;
             square.onclick = colorCell;
             rowDiv.appendChild(square);
@@ -134,7 +134,8 @@ function fillGrid() {
 
 /* Color one cell in the grid with the selected color. */
 function colorCell() {
-    grid[this.id[0]][this.id[1]].color = selectedColor;
+    let ids = this.id.split(" ");
+    grid[ids[0]][ids[1]].color = selectedColor;
 
     renderGrid();
 }


### PR DESCRIPTION
What changed:

1. grid.js

- fixed a bug which meant that coloring on individual cells outside of a 10 x 10 grid didn't work
- it colored other squares that wasn't the one that the user clicked on

Process and Solution:
After debugging though console.log and visually clicking the squares, I realized that when collecting the ids of the square for coloring, the ids were in the form of [row + "" + column] which gave results like "00", "21", or "120". Originally I only got the first and second character of the string, which meant that it was not collecting the entire number of the id, causing it to misplace the colors.

Fixing that meant that I had to properly split the values, using split(" ").  I added a space between the numbers and used that as a point to split the id into two numbers without cutting off anything. Then I was able to get the whole numbers for each of them. Values should be like id = "12 0" => split(" ") => result in ids [12, 0]. 

So processing the ids was the problem, it should be fixed now.